### PR TITLE
Ignore harmony imports with redirectId

### DIFF
--- a/lib/shake/plugin.js
+++ b/lib/shake/plugin.js
@@ -79,7 +79,8 @@ ShakePlugin.prototype.apply = function apply(compiler) {
         module.reasons.forEach((reason) => {
           // TODO(indutny): This should check that `dependency` inherits from
           // `ModuleDependency`
-          if (typeof reason.dependency.userRequest !== 'string')
+          if (typeof reason.dependency.userRequest !== 'string' ||
+              reason.dependency.redirectedId)
             return;
 
           if (reason.module === null)
@@ -127,10 +128,16 @@ ShakePlugin.prototype.apply = function apply(compiler) {
   });
 };
 
+function isHarmonyModule(module) {
+  const buildMeta = module.buildMeta;
+  if (!buildMeta) return false;
+  return !!buildMeta.harmonyModule || buildMeta.exportsType === 'namespace';
+}
+
 ShakePlugin.prototype.mapModule = function mapModule(state, compilation,
                                                      module) {
   // Skip Harmony Modules, we can't handle them anyway
-  if (module.buildMeta && module.buildMeta.harmonyModule)
+  if (isHarmonyModule(module))
     return module;
 
   // Don't wrap modules that we don't own

--- a/test/fixtures/complex/a.js
+++ b/test/fixtures/complex/a.js
@@ -1,0 +1,3 @@
+import { isEqual } from './pure-pkg';
+
+export const stuff = isEqual;

--- a/test/fixtures/complex/b.js
+++ b/test/fixtures/complex/b.js
@@ -1,0 +1,3 @@
+import { isEqual } from './pure-pkg';
+
+export const moreStuff = isEqual;

--- a/test/fixtures/complex/base.js
+++ b/test/fixtures/complex/base.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { stuff, moreStuff } = require('./loader');
+
+exports.allStuff = `${stuff(2, 2)} ${moreStuff(2, 3)}`;

--- a/test/fixtures/complex/loader.js
+++ b/test/fixtures/complex/loader.js
@@ -1,0 +1,2 @@
+export * from './a.js';
+export * from './b.js';

--- a/test/fixtures/complex/pure-pkg/index.js
+++ b/test/fixtures/complex/pure-pkg/index.js
@@ -1,0 +1,1 @@
+export * from './isEqual';

--- a/test/fixtures/complex/pure-pkg/isEqual.js
+++ b/test/fixtures/complex/pure-pkg/isEqual.js
@@ -1,0 +1,3 @@
+export function isEqual(a, b) {
+    return a === b;
+}

--- a/test/fixtures/complex/pure-pkg/package.json
+++ b/test/fixtures/complex/pure-pkg/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "pure-pkg",
+  "module": "./index.js",
+  "sideEffects": false,
+  "version": "1.0.20"
+}

--- a/test/plugin-test.js
+++ b/test/plugin-test.js
@@ -77,6 +77,14 @@ describe('webpack-common-shake', () => {
     });
   });
 
+  it('should compile `complex/base.js`', (cb) => {
+    compile('complex/base.js', (err, file) => {
+      assert.ok(!err);
+      assert.deepEqual(file, { allStuff: 'true false' });
+      cb();
+    });
+  });
+
   it('should remove unused exports of `unused-exports.js`', (cb) => {
     compile('unused-exports.js', (err, file, extra) => {
       assert.ok(!err);


### PR DESCRIPTION
The webpack 4 release of the plugin didn't properly handle some advanced cases (and who knows, maybe also some simpler ones I just haven't found yet). Specifically it broke when it encountered side-effect free ES6 modules that could be removed from the module graph entirely.

* Reproduction of the issue (`fixtures/complex`).
* A fix for (more) correctly ignoring ES6 modules during `mapModule`.
* A fix for (more) correctly ignoring ES6 modules when filtering for `analyzer.resolve`.

#### Original Description

This is more a bug report than a solution. For *some* reason in *some* situations (observed in a bigger app using `apollo-client`), `module.mergeFrom` is called for unresolved modules that have already been cleared. This triggers the unhelpful error "<null>.forEach isn't a function" when it hits `unresolved.uses.forEach`.

So far I have no real reproduction and I'm not sure yet what could trigger this scenario.

---
_This PR was started by: [git wf pr](https://github.groupondev.com/InteractionTier/workflow-cli/releases/tag/v1.7.0)_