### PR TITLE
fix(plugin): remove incorrect double quotes

### DIFF
--- a/lib/shake/plugin.js
+++ b/lib/shake/plugin.js
@@ -46,7 +46,7 @@ ShakePlugin.prototype.apply = function apply(compiler) {
     const state = new State();
 
     const parserHook = params.normalModuleFactory.hooks.parser;
-    for (const parserType of ['javascript/auto', '"javascript/dynamic']) {
+    for (const parserType of ['javascript/auto', 'javascript/dynamic']) {
       parserHook.for(parserType).tap('ShakePlugin', (parser, parserOptions) => {
         if (typeof parserOptions.commonjs !== 'undefined' &&
             !parserOptions.commonjs) {


### PR DESCRIPTION
I think this is a typo, just remove the incorrect double quotes.